### PR TITLE
Add "unread-entries" attribute to toolbar button

### DIFF
--- a/chrome/content/brief-overlay.js
+++ b/chrome/content/brief-overlay.js
@@ -223,6 +223,8 @@ const Brief = {
         query.getEntryCount(function(unreadEntriesCount) {
             Brief.statusCounter.value = unreadEntriesCount;
             Brief.statusCounter.hidden = (unreadEntriesCount == 0);
+            // For userChrome.css styles like #brief-button[unread-entries="0"] { ... }
+            Brief.toolbarbutton.setAttribute("unread-entries", unreadEntriesCount);
         })
     },
 


### PR DESCRIPTION
I leave

``` javascript
Brief.statusCounter.hidden = (unreadEntriesCount == 0); 
```

as is... This is probably faster and a bit shorten, than CSS. :)
