### PR TITLE
Relative URLs in feed content are not resolved

### DIFF
--- a/chrome/content/feedview.js
+++ b/chrome/content/feedview.js
@@ -906,14 +906,17 @@ function EntryView(aFeedView, aEntryData) {
         deleteButton.setAttribute('title', Strings.deleteEntryTooltip);
     }
 
+    let feed = Storage.getFeed(aEntryData.feedID);
+
+    // Set xml:base attribute to resolve relative URIs against the feed's URI.
+    this.container.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'base', feed.feedURL);
+
     let titleElem = this._getElement('title-link');
     if (aEntryData.entryURL)
         titleElem.setAttribute('href', aEntryData.entryURL);
 
     // Use innerHTML instead of textContent to resolve entities.
     titleElem.innerHTML = aEntryData.title || aEntryData.entryURL;
-
-    let feed = Storage.getFeed(aEntryData.feedID);
 
     this._getElement('feed-name').innerHTML = feed.title;
     this._getElement('authors').innerHTML = aEntryData.authors;


### PR DESCRIPTION
Even though relative URLs in feed content [are against the standard](http://www.rssboard.org/rss-profile#data-types-url), some feeds still use them.
