### PR TITLE
pull in getWebContentHandlerByURI through the correct interface

### DIFF
--- a/chrome/content/brief-overlay.js
+++ b/chrome/content/brief-overlay.js
@@ -121,11 +121,11 @@ const Brief = {
         const CONTENT_TYPE = 'application/vnd.mozilla.maybe.feed';
         const SUBSCRIBE_URL = 'brief://subscribe/%s';
 
-        let wchr = Cc['@mozilla.org/embeddor.implemented/web-content-handler-registrar;1']
-                   .getService(Ci.nsIWebContentHandlerRegistrar);
+        let wccs = Cc['@mozilla.org/embeddor.implemented/web-content-handler-registrar;1']
+                   .getService(Ci.nsIWebContentConverterService);
 
-        if (!wchr.getWebContentHandlerByURI(CONTENT_TYPE, SUBSCRIBE_URL))
-            wchr.registerContentHandler(CONTENT_TYPE, SUBSCRIBE_URL, 'Brief', null);
+        if (!wccs.getWebContentHandlerByURI(CONTENT_TYPE, SUBSCRIBE_URL))
+            wccs.registerContentHandler(CONTENT_TYPE, SUBSCRIBE_URL, 'Brief', null);
 
         if (this.prefs.getBoolPref('firstRun')) {
             this.onFirstRun();


### PR DESCRIPTION
Broke somewhere near Firefox 30 as getWebContentHandlerByURI was not available

Should fix ancestorak/brief#68
