### PR TITLE
_feedToEntries: don't assume every item has a link

### DIFF
--- a/scripts/database.js
+++ b/scripts/database.js
@@ -763,7 +763,7 @@ let Database = {
                 feedID: feed.feedID,
                 providedID: src.id,
                 title: (src.title || '').replace(/<[^>]+>/g, ''), // Strip tags
-                entryURL: src.link.href,
+                entryURL: src.link ? src.link.href : '',
                 summary: src.summary,
                 content: src.content,
                 authors: authors,


### PR DESCRIPTION
I've been a big Brief fan for many years! Thanks for my favorite RSS reader.

This patch fixes an error thrown when Brief tries to parse a feed where at least one item doesn't have a `<link>` element.