### PR TITLE
Remove deprecated and ignored CSS properties

### DIFF
--- a/skin/brief.css
+++ b/skin/brief.css
@@ -13,10 +13,6 @@
     background: none !important;
     border: 0 !important;
     box-shadow: none !important;
-    -moz-border-bottom-colors: none !important;
-    -moz-border-left-colors: none !important;
-    -moz-border-right-colors: none !important;
-    -moz-border-top-colors: none !important;
 }
 
 /* Generic boxes */


### PR DESCRIPTION
`-moz-border-bottom-colors` and friends is deprecated and ignored.

Details: https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-border-bottom-colors