### PR TITLE
Badge text color

### DIFF
--- a/background.js
+++ b/background.js
@@ -31,6 +31,11 @@ const Brief = {
             () => browser.tabs.create({url: '/ui/brief.xhtml'}));
         browser.browserAction.setBadgeBackgroundColor({color: 'grey'});
 
+        if(typeof browser.browserAction.setBadgeTextColor === "function")
+        {  
+           browser.browserAction.setBadgeTextColor({color: "#F8F8F8"});
+        } 
+
         browser.contextMenus.create({
             id: "brief-button-refresh",
             title: browser.i18n.getMessage("briefCtxRefreshFeeds_label"),


### PR DESCRIPTION
Make badge text color light, so it can still be read in Firefox 63+. 

Starting in Firefox 63, the default text color for browserAction badges is now automatically set to black or white, to maximise contrast with the background (https://bugzilla.mozilla.org/show_bug.cgi?id=1474110). It seems to be, that this doesn't work that well. The text is displayed in black in the case of brief, which makes it pretty hard to read.