### PR TITLE
Expose delay options

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -287,6 +287,24 @@
     "nextFeed_accesskey": {
         "message": "N"
     },
+    "defaultFetchDelayBefore_label": {
+        "message": "Wait"
+    },
+    "defaultFetchDelayAfter_label": {
+        "message": "seconds between individual feed syncs"
+    },
+    "defaultFetchDelay_accesskey": {
+        "message": "F"
+    },
+    "backgroundFetchDelayBefore_label": {
+        "message": "Wait"
+    },
+    "backgroundFetchDelayAfter_label": {
+        "message": "seconds between individual feed syncs when in background"
+    },
+    "backgroundFetchDelay_accesskey": {
+        "message": "B"
+    },
 
   // Messages from overlay.dtd
     // Toolbar button context menu

--- a/skin/options.css
+++ b/skin/options.css
@@ -32,6 +32,10 @@ hbox.line > * {
     margin-right: 0.5em;
 }
 
+hbox.high {
+    line-height: 2em;
+}
+
 body {
     width: -moz-max-content;
 }

--- a/ui/options/options.xhtml
+++ b/ui/options/options.xhtml
@@ -32,6 +32,22 @@
                data-i18n-attrs="accesskey:showNotification_accesskey">
             <input type="checkbox" data-pref="update.showNotification"/>
         </label>
+        <hbox class="line">
+            <label data-i18n="defaultFetchDelayBefore_label"/>
+            <input type="number" min="0" id="defaultFetchDelay"
+                data-pref="update.defaultFetchDelay"
+                data-pref-scale="1000"
+                data-i18n-attrs="accesskey:defaultFetchDelay_accesskey"/>
+            <label data-i18n="defaultFetchDelayAfter_label"/>
+        </hbox>
+        <hbox class="line">
+            <label data-i18n="backgroundFetchDelayBefore_label"/>
+            <input type="number" min="0" id="backgroundFetchDelay"
+                data-pref="update.backgroundFetchDelay"
+                data-pref-scale="1000"
+                data-i18n-attrs="accesskey:backgroundFetchDelay_accesskey"/>
+            <label data-i18n="backgroundFetchDelayAfter_label"/>
+        </hbox>
     </div>
     <div align="stretch">
         <h2 data-i18n="readingGroup_caption"/>

--- a/ui/options/options.xhtml
+++ b/ui/options/options.xhtml
@@ -32,7 +32,7 @@
                data-i18n-attrs="accesskey:showNotification_accesskey">
             <input type="checkbox" data-pref="update.showNotification"/>
         </label>
-        <hbox class="line">
+        <hbox class="line high">
             <label data-i18n="defaultFetchDelayBefore_label"/>
             <input type="number" min="0" id="defaultFetchDelay"
                 data-pref="update.defaultFetchDelay"
@@ -40,7 +40,7 @@
                 data-i18n-attrs="accesskey:defaultFetchDelay_accesskey"/>
             <label data-i18n="defaultFetchDelayAfter_label"/>
         </hbox>
-        <hbox class="line">
+        <hbox class="line high">
             <label data-i18n="backgroundFetchDelayBefore_label"/>
             <input type="number" min="0" id="backgroundFetchDelay"
                 data-pref="update.backgroundFetchDelay"


### PR DESCRIPTION
This adds option for users to choose delay between individual feed synchronizations.
It was also mentioned in already closed #282. 
Why is there a delay in the first place anyway? I experimented with various values including 0 and saw no difference though I am aware that even 0 means non-zero due to setTimeout implementation. Git log just mentioned big update and correct scheduling.