### PR TITLE
[wip] add button+hotkey to open all entries in view at once

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -74,6 +74,10 @@
     "markViewRead_tooltip": {
         "message": "Mark all items as read (Alt + N)"
     },
+    "openCurrentView_tooltip": {
+        "message": "Open all listed items in new tabs (O)"
+    },
+
 
     // # Context menu
     "ctxMarkRead_label": {

--- a/skin/feedview-header.css
+++ b/skin/feedview-header.css
@@ -101,6 +101,28 @@
     background-position: 0 -44px !important;
 }
 
+#open-current-view {
+    background-image: url(/icons/mark-view-read.png) !important;
+}
+
+.view-button,
+#open-current-view {
+    height: 22px !important;
+    width: 22px !important;
+    background-position: 0 0 !important;
+}
+
+.view-button:hover,
+#open-current-view:hover {
+    background-position: 0 -22px !important;
+}
+
+.view-button:hover:active,
+#open-current-view:hover:active,
+.view-button[data-checked=true] {
+    background-position: 0 -44px !important;
+}
+
 #headlines-checkbox {
     background-image: url(/icons/view-headlines.png) !important;
 }

--- a/ui/brief.js
+++ b/ui/brief.js
@@ -114,6 +114,14 @@ export let Commands = {
         Database.query(gCurrentView.query).markRead(true);
     },
 
+    openCurrentView: async function cmd_openCurrentView() {
+        const entries = await Database.query(gCurrentView.query).getEntries();
+        this.markViewRead();
+        for (let entry of entries) {
+            openBackgroundTab(entry.entryURL);
+        }
+    },
+
     markVisibleEntriesRead: function cmd_markVisibleEntriesRead() {
         gCurrentView.markVisibleEntriesRead();
     },
@@ -339,6 +347,7 @@ let FeedViewHeader = {
         Searchbar.init();
         const handlers = {
             'mark-view-read': event => this.markRead(event),
+            'open-current-view': () => Commands.openCurrentView(),
             'headlines-checkbox': () => Commands.switchViewMode('headlines'),
             'full-view-checkbox': () => Commands.switchViewMode('full'),
             'show-all-entries-checkbox': () => Commands.switchViewFilter('all'),
@@ -499,6 +508,7 @@ export let Shortcuts = {
             case 'm': Commands.toggleSelectedEntryRead(); break;
             case 'n': Commands.markVisibleEntriesRead(); break;
             case 'Alt+n': Commands.markViewRead(); break;
+            case 'o': Commands.openCurrentView(); break;
             case 't': Commands.deleteOrRestoreSelectedEntry(); break;
             case 'b': Commands.toggleSelectedEntryStarred(); break;
             case 'h': Commands.toggleSelectedEntryCollapsed(); break;

--- a/ui/brief.xhtml
+++ b/ui/brief.xhtml
@@ -121,6 +121,9 @@
             <button id="mark-view-read"
                     class="brief-button feed-header-button"
                     data-i18n-attrs="title:markViewRead_tooltip"/>
+            <button id="open-current-view"
+                class="brief-button feed-header-button"
+                data-i18n-attrs="title:openCurrentView_tooltip"/>
             <div class="spacer button-spacer"/>
             <button id="headlines-checkbox"
                     class="brief-button view-button"


### PR DESCRIPTION
This QoL improvement prevents mornings (or any visit online after a brief time offline) from turning into a clickfest where users strive to open every unread feed from view.

I'm looking for feedback about the following:
1. the button icon. Could you provide one or point me to direction to get one? 
2. the actual button function. Making it open only unread entries can be easily achieved using controls already in the UI, so current implementation offers more possibilities but... being on All Items view and forgetting to select Unread can be unfortunate if you have 50 tabs open and 700 entries total in the DB.