### PR TITLE
database: `async` migration

### DIFF
--- a/modules/database.js
+++ b/modules/database.js
@@ -1824,7 +1824,6 @@ export let Migrator = {
 
 /// Misc utilities for working with databases
 const DbUtil = {
-    // Note: this is resolved after the transaction is finished(!!!) mb1193394
     requestPromise(req) {
         return new Promise((resolve, reject) => {
             req.onsuccess = (event) => resolve(event.target.result);

--- a/modules/database.js
+++ b/modules/database.js
@@ -1176,7 +1176,7 @@ Query.prototype = {
         Comm.verbose && console.log('DB _update');
         let cursors = ranges.map(r => index.openCursor(r, "prev"));
         if(cursors.length === 0) {
-            then && then({tx, feeds, entries});
+            then && then({tx});
             await DbUtil.transactionPromise(tx);
             return;
         }
@@ -1194,7 +1194,7 @@ Query.prototype = {
                     cursor.continue();
                 } else {
                     if(target.then) {
-                        target.then({tx, feeds, entries});
+                        target.then({tx});
                     }
                 }
             };

--- a/modules/database.js
+++ b/modules/database.js
@@ -220,6 +220,7 @@ export let Database = {
                     ["feedID", "providedID", "entryURL"]
                 );
             // fallthrough
+            // TODO: validate entries for undefined entryURL
         }
         for(let index of ["primaryHash", "feedID_providedID", "feedID_entryURL"]) {
             let entries = tx.objectStore('entries');
@@ -1164,6 +1165,9 @@ Query.prototype = {
 
         let store = tx.objectStore('entries');
         let index = indexName ? store.index(indexName) : store;
+
+        // It's possible to win 10-15% speed for the "many tiny cursors" scenario
+        // by trying getAll first, but not worth the extra code
 
         // Wait for all callbacks
         let resolve;

--- a/modules/database.js
+++ b/modules/database.js
@@ -629,7 +629,7 @@ export let Database = {
         }
         // Scan 1: every entry with IDs provided
         console.debug('_pushFeedEntries: search by ID...');
-        await this.query(queryId)._update({
+        await this.query(queryId)._forEach({
             tx,
             action: (entry, {tx}) => {
                 let update = entriesById.get(entry.providedID);
@@ -642,7 +642,6 @@ export let Database = {
                 }
                 this._updateEntry(entry, update, {tx, markUnread, entries: allEntries});
             },
-            wait: 'callbacks',
         });
 
         let entriesByUrl = new Map();
@@ -662,7 +661,7 @@ export let Database = {
         };
         // Scan 2: URL-only entries
         console.debug('_pushFeedEntries: search by URL...');
-        await this.query(queryUrl)._update({
+        await this.query(queryUrl)._forEach({
             tx,
             // changes undefined to avoid duplicate notifications
             action: (entry, {tx}) => {
@@ -678,7 +677,6 @@ export let Database = {
                 }
                 this._updateEntry(entry, update, {tx, markUnread, entries: allEntries});
             },
-            wait: 'callbacks',
         });
         console.debug('_pushFeedEntries: insert new entries...');
         // Part 3: completely new entries
@@ -757,7 +755,7 @@ export let Database = {
             revision.title = next.title;
             revision.content = next.content || next.summary;
             revision.authors = next.authors;
-            tx.objectStore('entries').put(prev); // Sorry, _update's default save is before
+            tx.objectStore('entries').put(prev);
             tx.objectStore('revisions').put(revision);
             entries.push(prev);
         };

--- a/modules/database.js
+++ b/modules/database.js
@@ -1209,7 +1209,7 @@ Query.prototype = {
         });
         cursors[cursors.length - 1].resolve = resolve;
         await DbUtil.transactionPromise(tx);
-        if(changes) {
+        if(changes && entries.length > 0) {
             //TODO: we're missing revision data here
             Comm.broadcast('entries-updated', {
                 feeds: Array.from(feeds),

--- a/modules/database.js
+++ b/modules/database.js
@@ -1837,8 +1837,8 @@ const DbUtil = {
         return new Promise((resolve, reject) => {
             let oncomplete = tx.oncomplete;
             let onerror = tx.onerror;
-            tx.oncomplete = () => { resolve(); if(oncomplete) oncomplete(); };
-            tx.onerror = () => { reject(); if(onerror) onerror(); };
+            tx.oncomplete = () => { if(oncomplete) oncomplete(); resolve(); };
+            tx.onerror = () => { if(onerror) onerror(); reject(); };
         });
     },
 };

--- a/modules/database.js
+++ b/modules/database.js
@@ -1151,7 +1151,7 @@ Query.prototype = {
         await Promise.all(actions);
     },
 
-    async _update({action, stores, changes, then, tx, wait='transaction'}) {
+    async _update({action, stores, changes, tx, wait='transaction'}) {
         if(stores === undefined) {
             stores = ['entries'];
         }
@@ -1175,7 +1175,7 @@ Query.prototype = {
 
         // Wait for all callbacks
         let resolve;
-        let callbackPromise = new Promise(r => resolve = r).then(then);
+        let callbackPromise = new Promise(r => resolve = r);
 
         Comm.verbose && console.log('DB _update');
         let cursors = ranges.map(r => index.openCursor(r, "prev"));

--- a/test/_index.js
+++ b/test/_index.js
@@ -3,3 +3,4 @@ import "./query.js";
 import "./migration.js";
 import "./opml.js";
 import "./regression.js";
+import "./benchmarks.js";


### PR DESCRIPTION
Raw IndexedDB code tends to become kind of callback hell. After Firefox implemented correctly the microtask/promise interaction (i.e. the ability to resolve a promise and have its callbacks run before the transaction auto-commits) it's possible to write the same code with `async`/`await`, which is much more maintainable.