### PR TITLE
Squash entries with duplicate providedID on fetch

### DIFF
--- a/modules/database.js
+++ b/modules/database.js
@@ -789,6 +789,18 @@ export let Database = {
         let ids = entries.map(e => e.providedID).filter(i => i);
         if(ids.length !== (new Set(ids)).size) {
             console.error('feed has duplicate item IDs', feed, parsedFeed);
+            let seenIds = new Set()
+            entries = entries.filter(e => {
+              // Keep entries that don't have providedID
+              if(!e.providedID) {
+                return true;
+              } else if(seenIds.has(e.providedID)) {
+                return false;
+              } else {
+                seenIds.add(e.providedID);
+                return true;
+              }
+            });
         }
         let urls = entries.map(e => e.entryURL).filter(u => u);
         if(urls.length !== (new Set(urls)).size) {


### PR DESCRIPTION
aside: I did this against master. Not sure if it should be against 2.6?

fixes #344

Previously if a there were duplicate providedIDs in a feed's refresh
entry list then a new item would be created in Brief. This behavior
could still occur on fallback to using entryURL.

Future work, only include the entry with the newest updated timestamp.
Although, feeds may already be ordered in this manner and as such futher
processing is not required (status: tbd).

==

Little more detail on why the duplicates were occuring and why this fix
works.

During "Scan 1: every entry with IDs provided" a map of providedID to
entry is created. Which, inevitably, squashes the duplicate providedID.
A lookup on all the providedIDs is made and if found the entry from the
map is added to the "found" set.

Since this "found" set will only ever have one of the duplicated
entries, when a difference on the "found" set and "entries" (everything)
is made the duplicates appear as "leftovers" or new results.

By squashing the duplicates in the "entries" list (what this patch does)
we avoid the leftover situation.