### PR TITLE
enable Typescript for linting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@ test/ export-ignore
 .git* export-ignore
 .eslintrc.yml export-ignore
 package.json export-ignore
+tsconfig.json export-ignore

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Brief requires the following permissions:
 - `storage`/`unlimitedStorage` ("Store unlimited amount of client-side data") to store the items from your feeds
 - `bookmarks` ("Read and modify bookmarks") to bookmark starred items and star your bookmarks
 - `notifications` ("Display notifications to you") to tell you about new items found
-- `contextMenus` (not displayed) to provide the Brief button context menu
+- `menus` (not displayed) to provide the Brief button context menu
 - `tabs` ("Access browser tabs") to see subscribing via old subscription/preview pages
 - `downloads` ("Download files and read and modify the browser's download history") to be able to export feed list and (not implemented yet) backup the database
 - `webRequest` and `webRequestBlocking` (not displayed) to intercept the feed requests correctly and activate the feed preview mode instead of the download prompt

--- a/background.js
+++ b/background.js
@@ -25,6 +25,7 @@ const Brief = {
     async init() {
         Comm.initMaster();
 
+        // @ts-ignore Types do not know about the temporary flag
         browser.runtime.onInstalled.addListener(async ({temporary}) => {
             if(temporary) { // `web-ext run` or equivalent
                 Comm.verbose = true;
@@ -165,6 +166,7 @@ const Brief = {
         if(matchSubscribe) {
             let url = decodeURIComponent(matchSubscribe.pop());
             Database.addFeeds({url});
+            // @ts-ignore Types do not know that the tab ID is optional
             browser.tabs.update({url: '/ui/brief.xhtml'});
         }
         try {

--- a/background.js
+++ b/background.js
@@ -46,28 +46,28 @@ const Brief = {
             () => browser.tabs.create({url: '/ui/brief.xhtml'}));
         browser.browserAction.setBadgeBackgroundColor({color: '#666666'});
 
-        browser.contextMenus.create({
+        browser.menus.create({
             id: "brief-button-refresh",
             title: browser.i18n.getMessage("briefCtxRefreshFeeds_label"),
             contexts: ["browser_action"]
         });
-        browser.contextMenus.create({
+        browser.menus.create({
             id: "brief-button-mark-read",
             title: browser.i18n.getMessage("briefCtxMarkFeedsAsRead_label"),
             contexts: ["browser_action"]
         });
-        browser.contextMenus.create({
+        browser.menus.create({
             id: "brief-button-show-unread",
             type: "checkbox",
             title: browser.i18n.getMessage("briefCtxShowUnreadCounter_label"),
             contexts: ["browser_action"]
         });
-        browser.contextMenus.create({
+        browser.menus.create({
             id: "brief-button-options",
             title: browser.i18n.getMessage("briefCtxShowOptions_label"),
             contexts: ["browser_action"]
         });
-        browser.contextMenus.onClicked.addListener(info => this.onContext(info));
+        browser.menus.onClicked.addListener(info => this.onContext(info));
 
         let browserInfo = await browser.runtime.getBrowserInfo();
         let baseVersion = browserInfo.version.split('.')[0];
@@ -230,7 +230,7 @@ const Brief = {
     _updateUI: async function() {
 
         let enabled = Prefs.get('showUnreadCounter');
-        browser.contextMenus.update('brief-button-show-unread', {checked: enabled});
+        browser.menus.update('brief-button-show-unread', {checked: enabled});
         if(enabled) {
             let count = await Database.query({
                 deleted: 0,

--- a/background.js
+++ b/background.js
@@ -121,7 +121,7 @@ const Brief = {
         }
     },
 
-    onContext: function({menuItemId, checked}) {
+    onContext: function({menuItemId, checked=null}) {
         switch(menuItemId) {
             case 'brief-button-refresh':
                 Comm.broadcast('update-all');
@@ -160,7 +160,7 @@ const Brief = {
     BRIEF_SUBSCRIBE: new RegExp(
         "(chrome://brief/content/brief\\.(xul|xhtml)\\?subscribe=|brief://subscribe/)(.*)"),
 
-    async queryFeeds({windowId, tabId, url, title, status}) {
+    async queryFeeds({windowId, tabId, url=undefined, title=undefined, status=undefined}) {
         let replies = [[]];
         let matchSubscribe = this.BRIEF_SUBSCRIBE.exec(url);
         if(matchSubscribe) {

--- a/background.js
+++ b/background.js
@@ -78,7 +78,7 @@ const Brief = {
             /*spawn*/ RequestMonitor.init();
         }
 
-        await Prefs.init({master: true});
+        await Prefs.init();
 
         Prefs.addObserver('showUnreadCounter', () => this._updateUI());
         Comm.registerObservers({

--- a/background.js
+++ b/background.js
@@ -170,10 +170,10 @@ const Brief = {
             browser.tabs.update({url: '/ui/brief.xhtml'});
         }
         try {
-            replies = await browser.tabs.executeScript(tabId, {
+            replies = /** @type {{kind, url}[][]} */(await browser.tabs.executeScript(tabId, {
                 file: '/content_scripts/scan-for-feeds.js',
                 runAt: 'document_end',
-            });
+            }));
         } catch(ex) {
             if(ex.message === 'Missing host permission for the tab') {
                 // There are a few known cases: about:, restricted (AMO) and feed preview pages

--- a/background.js
+++ b/background.js
@@ -22,7 +22,7 @@ const Brief = {
     _firefoxPreviewWorkaround: false,
 
     // No deinit required, we'll be forcefully unloaded anyway
-    init: async function() {
+    async init() {
         Comm.initMaster();
 
         browser.runtime.onInstalled.addListener(async ({temporary}) => {

--- a/background.js
+++ b/background.js
@@ -350,4 +350,5 @@ const Brief = {
 Brief.init();
 
 // Debugging hook
+// @ts-ignore
 window.Brief = Brief;

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
         }
     },
     "default_locale": "en",
-    "permissions": ["<all_urls>", "contextMenus", "bookmarks",
+    "permissions": ["<all_urls>", "menus", "bookmarks",
         "storage", "unlimitedStorage", "downloads", "tabs", "notifications",
         "webRequest", "webRequestBlocking"],
     "background": {

--- a/modules/database.js
+++ b/modules/database.js
@@ -1216,6 +1216,7 @@ Query.prototype = {
         // by trying getAll first, but not worth the extra code
 
         // Wait for all callbacks
+        /** @type function */
         let resolve;
         let callbackPromise = new Promise(r => resolve = r);
 

--- a/modules/database.js
+++ b/modules/database.js
@@ -157,6 +157,7 @@ export let Database = {
         if(upgrade !== null) {
             opener.onupgradeneeded = (event) => upgrade(event);
         } else {
+            // @ts-ignore Types do not know about transaction (what its target is)
             opener.onupgradeneeded = ({target: {transaction: tx}, oldVersion}) => {
                 upgradeFrom = oldVersion;
                 tx.abort();
@@ -1788,6 +1789,7 @@ export let Migrator = {
         if(processedEntries === count.entries) {
             // Everything already transferred and presumably already flushed
             console.info("Migration already done, dropping the old database");
+            // @ts-ignore Types do not know the storage option
             indexedDB.deleteDatabase(source.db.name, {storage: 'persistent'});
             return;
         }

--- a/modules/database.js
+++ b/modules/database.js
@@ -585,7 +585,7 @@ export let Database = {
         if(!entries.length || (modified && modified <= feed.dateModified)) {
             return {entries: [], newEntries: []};
         }
-        let newEntries = await this._pushEntries({feed, entries});
+        let newEntries = await this._pushEntries({entries});
         let feedUpdates = Object.assign({}, {
             feedID: feed.feedID,
             title: feed.title || parsedFeed.title,

--- a/modules/database.js
+++ b/modules/database.js
@@ -591,7 +591,7 @@ export let Database = {
             title: feed.title || parsedFeed.title,
             websiteURL: parsedFeed.link ? parsedFeed.link.href : '',
             subtitle: parsedFeed.subtitle ? parsedFeed.subtitle.text : '',
-            oldestEntryDate: Math.min(entries.map(e => e.date)) || feed.oldestEntryDate,
+            oldestEntryDate: Math.min(...entries.map(e => e.date)) || feed.oldestEntryDate,
             language: parsedFeed.language,
             lastUpdated: Date.now(),
             dateModified: modified,

--- a/modules/database.js
+++ b/modules/database.js
@@ -1428,7 +1428,7 @@ Query.prototype = {
         }
 
         // What fields off the index we can use at all?
-        let optionSets = indexPath.map(name => ({name, values: filters.entry[name]}));
+        let optionSets = indexPath.map(name => ({name, values: filters.entry[name], range: null}));
         while(optionSets.length && optionSets[optionSets.length - 1].values === undefined) {
             let set = optionSets[optionSets.length - 1];
             if(set.name === filters.sort.field) {

--- a/modules/feed-fetcher.js
+++ b/modules/feed-fetcher.js
@@ -33,7 +33,7 @@ export async function fetchFeed(feed, {allow_cached = false} = {}) {
     }
 
     let result = parseNode(root, FEED_PROPERTIES);
-    if(!result || !result.items || !result.items.length > 0) {
+    if(!result || !result.items || !(result.items.length > 0)) {
         console.warn("failed to find any items in", url);
     } else {
         let item = result.items[0];

--- a/modules/feed-fetcher.js
+++ b/modules/feed-fetcher.js
@@ -269,7 +269,7 @@ const HANDLERS = {
         let text = node.textContent.trim();
         // Support for Z timezone marker for UTC (mb 682781)
         let date = new Date(text.replace(/z$/i, "-00:00"));
-        if (!isNaN(date)) {
+        if (!isNaN(date.getTime())) {
             return date.toUTCString();
         }
         console.warn('failed to parse date', text);

--- a/modules/prefs.js
+++ b/modules/prefs.js
@@ -17,7 +17,7 @@ export let Prefs = {
     // When splitting default and user prefs these values are considered default
     _defaultEquivalent: {},
 
-    init: async function() {
+    async init() {
         if(this.ready()) {
             return;
         }

--- a/modules/request-monitor.js
+++ b/modules/request-monitor.js
@@ -68,7 +68,8 @@ const MAYBE_FEED_TYPES = [
     // and anything with `+xml` as a special case
 ];
 
-async function checkHeaders({requestId, tabId, url, responseHeaders}) {
+// Headers are formally optional, but always present because of 'responseHeaders' requirement
+async function checkHeaders({requestId, tabId, url, responseHeaders=null}) {
     if(tabId === browser.tabs.TAB_ID_NONE) {
         return; // This is not a real tab, so not redirecting anything
     }

--- a/modules/updater.js
+++ b/modules/updater.js
@@ -231,7 +231,7 @@ export let FeedUpdater = {
                 'updateAlertText_multpleFeedsMessage', [newString, itemString, feedString]);
             alertText = alertText
                 .replace('#numItems', entryCount)
-                .replace('#numFeeds', feedCount);
+                .replace('#numFeeds', feedCount.toString());
         }
         browser.notifications.create({
             type: 'basic',

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "private": true,
   "devDependencies": {
-    "eslint": "^6.8.0",
+    "eslint": "^7.22.0",
     "eslint-import-resolver-babel-root-slash-import": "^1.0.6",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-json": "^2.0.1",
-    "typescript": "^3.9.5"
+    "typescript": "^4.2.3"
   },
   "scripts": {
     "lint": "eslint . --ext .json --ext .js"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "eslint-import-resolver-babel-root-slash-import": "^1.0.6",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-json": "^2.0.1",
-    "typescript": "^4.2.3"
+    "typescript": "^4.2.3",
+    "web-ext-types": "^3.2.1"
   },
   "scripts": {
     "lint": "eslint . --ext .json --ext .js"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "web-ext-types": "^3.2.1"
   },
   "scripts": {
-    "lint": "eslint . --ext .json --ext .js"
+    "eslint": "eslint . --ext .json --ext .js",
+    "tsc": "tsc",
+    "lint": "tsc ; eslint . --ext .json --ext .js"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
 	"baseUrl": ".",
 	"paths": {
 	    "/*": ["*"]
-	}
+	},
+	"typeRoots": ["node_modules/web-ext-types"]
     },
     "include": ["modules", "ui", "background.js"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+        "allowJs": true,
+	"checkJs": true,
+	"noEmit": true,
+	"target": "es6",
+	"lib": ["es6", "dom"]
+    },
+    "include": ["modules", "ui", "background.js"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,11 @@
 	"checkJs": true,
 	"noEmit": true,
 	"target": "es6",
-	"lib": ["es6", "dom"]
+	"lib": ["es6", "dom"],
+	"baseUrl": ".",
+	"paths": {
+	    "/*": ["*"]
+	}
     },
     "include": ["modules", "ui", "background.js"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 	"checkJs": true,
 	"noEmit": true,
 	"target": "es6",
-	"lib": ["es6", "dom"],
+	"lib": ["es2018", "dom", "dom.iterable"],
 	"baseUrl": ".",
 	"paths": {
 	    "/*": ["*"]

--- a/ui/brief.js
+++ b/ui/brief.js
@@ -177,7 +177,7 @@ async function refreshProgressmeter({active, progress}) {
     element.value = progress;
     if (active) {
         getElement('sidebar-top').dataset.mode = "update";
-        element.setAttribute('show', true); //TODO: css?
+        element.setAttribute('show', "true"); //TODO: css?
     }
     else {
         getElement('sidebar-top').dataset.mode = "idle";

--- a/ui/brief.js
+++ b/ui/brief.js
@@ -138,15 +138,15 @@ async function init() {
             now: Date.now(),
         });
         entries.reverse();
-        entries = entries.map(e => Database._entryFromItem(e));
-        for(let [i, e] of entries.entries()) {
+        let dbEntries = entries.map(e => Database._entryFromItem(e));
+        for(let [i, e] of dbEntries.entries()) {
             e.id = i;
         }
 
         setCurrentView(new FeedView({
             title: parsedFeed.title,
             feeds: [feed],
-            entries,
+            entries: dbEntries,
             filter: 'all',
             mode: 'full',
         }));

--- a/ui/brief.js
+++ b/ui/brief.js
@@ -376,6 +376,9 @@ export let Shortcuts = {
 init();
 
 // Debugging hooks
+// @ts-ignore
 window.Comm = Comm;
+// @ts-ignore
 window.Database = Database;
+// @ts-ignore
 window.Prefs = Prefs;

--- a/ui/feedlist.js
+++ b/ui/feedlist.js
@@ -1256,6 +1256,7 @@ export let Commands = {
     displayShortcuts: async function cmd_displayShortcuts() {
         let windows = await browser.windows.getAll({windowTypes: ['popup']});
         // Compat: fixed in Firefox 58
+        // @ts-ignore Types do not know about the `title` field
         windows = windows.filter(w => w.type === 'popup' && w.title.includes("Brief"));
         if(windows.length > 0) {
             browser.windows.update(windows[0].id, {focused: true});

--- a/ui/feedlist.js
+++ b/ui/feedlist.js
@@ -774,7 +774,7 @@ export let FeedList = {
             if(event.key === 'Enter') {
                 event.preventDefault();
                 event.stopPropagation();
-                document.activeElement.blur();
+                (/** @type HTMLElement */(document.activeElement)).blur();
             }
             if(event.key === 'Escape') {
                 event.preventDefault();
@@ -869,7 +869,8 @@ export let ContextMenuModule = {
         this._currentTarget = null;
         Array.from(document.querySelectorAll('context-menu.visible')).forEach(node => {
             node.classList.remove('visible');
-            node.parentNode.classList.remove('menu-visible');
+            let container = /** @type Element */ (node.parentNode);
+            container.classList.remove('menu-visible');
         });
     },
 
@@ -1017,7 +1018,9 @@ export let FeedListContextMenu = {
 
         if(!folder) {
             this.targetFeed = FeedList.getFeed(FeedList.selectedItem.dataset.id);
-            document.getElementById('ctx-open-website').disabled = !this.targetFeed.websiteURL;
+            // FIXME at the moment this is a noop anyway, no one checks that disabled
+            //let openWebsite = /** @type HTMLElement */ (document.getElementById('ctx-open-website'));
+            //openWebsite.disabled = !this.targetFeed.websiteURL;
         }
     },
 
@@ -1067,7 +1070,7 @@ export let FeedListContextMenu = {
 
 export let DropdownMenus = {
     build() {
-        let opmlInput = document.getElementById('open-opml');
+        let opmlInput = /** @type HTMLInputElement */ (document.getElementById('open-opml'));
         const handlers = {
             'dropdown-shortcuts': () => Commands.displayShortcuts(),
             'dropdown-import': () => opmlInput.click(),
@@ -1270,8 +1273,7 @@ export let Commands = {
         let {custom_css: style} = await browser.storage.local.get({'custom_css': ''});
         let blob = new Blob([style], {type: 'text/css'});
         let url = URL.createObjectURL(blob);
-        document.getElementById('custom-css').href = url;
-        let content = document.getElementById('feed-view').contentDocument;
-        content.getElementById('custom-css').href = url;
+        (/** @type HTMLLinkElement */ (document.getElementById('custom-css'))).href = url;
+        gCurrentView.document.getElementById('custom-css').href = url;
     },
 };

--- a/ui/feedlist.js
+++ b/ui/feedlist.js
@@ -40,8 +40,6 @@ TreeView.prototype = {
         }
         let event = new Event("change", {bubbles: true, cancelable: false});
         this.root.dispatchEvent(event);
-
-        return aElementOrId;
     },
 
     update: function TreeView_update(aModel) {
@@ -308,7 +306,6 @@ export let ViewList = {
 
     set selectedItem(aItem) {
         this.tree.selectedItem = aItem;
-        return aItem;
     },
 
     init: function ViewList_init(db) {

--- a/ui/feedlist.js
+++ b/ui/feedlist.js
@@ -294,11 +294,7 @@ TreeView.prototype = {
 
 export let ViewList = {
     db: null,
-
-    get tree() {
-        delete this.tree;
-        return this.tree = new TreeView('view-list');
-    },
+    tree: null,
 
     get selectedItem() {
         return this.tree.selectedItem;
@@ -310,6 +306,7 @@ export let ViewList = {
 
     init(db) {
         this.db = db;
+        this.tree = new TreeView('view-list');
         this.tree.root.addEventListener(
             'change', () => this.onSelect(), {passive: true});
 
@@ -406,6 +403,7 @@ export let ViewList = {
 
 export let TagList = {
     db: null,
+    tree: null,
 
     ready: false,
 
@@ -413,6 +411,7 @@ export let TagList = {
 
     init(db) {
         this.db = db;
+        this.tree = new TreeView('tag-list');
         this.tree.root.addEventListener(
             'change', () => this.onSelect(), {passive: true});
 
@@ -421,11 +420,6 @@ export let TagList = {
 
     get selectedItem() {
         return this.tree.selectedItem;
-    },
-
-    get tree() {
-        delete this.tree;
-        return this.tree = new TreeView('tag-list');
     },
 
     show: async function TagList_show() {
@@ -523,11 +517,13 @@ export let TagList = {
 export let FeedList = {
 
     db: null,
+    tree: null,
     _feedsCache: null,
     _built: false,
 
     init(db) {
         this.db = db;
+        this.tree = new TreeView('feed-list');
         // TODO: observers should be here
         this._feedsCache = this.db.feeds;
         this.tree.root.addEventListener(
@@ -566,11 +562,6 @@ export let FeedList = {
         }
 
         return null;
-    },
-
-    get tree() {
-        delete this.tree;
-        return this.tree = new TreeView('feed-list');
     },
 
     get selectedItem() {
@@ -909,7 +900,9 @@ export let ContextMenuModule = {
 
 
 export let ViewListContextMenu = {
+    menu: null,
     build() {
+        this.menu = document.getElementById('view-list-context-menu');
         const handlers = {
             'ctx-mark-special-folder-read': () => this.markFolderRead(),
             'ctx-restore-trashed': () => Commands.restoreTrashed(),
@@ -922,11 +915,6 @@ export let ViewListContextMenu = {
         }
         document.getElementById('view-list-context-menu')
             .addEventListener('show', () => this.prepare());
-    },
-
-    get menu() {
-        delete this.menu;
-        return this.menu = document.getElementById('view-list-context-menu');
     },
 
     targetItem: null,
@@ -984,7 +972,9 @@ export let TagListContextMenu = {
 
 
 export let FeedListContextMenu = {
+    menu: null,
     build() {
+        this.menu = document.getElementById('feed-list-context-menu');
         const handlers = {
             'ctx-mark-feed-read': () => this.markFeedRead(),
             'ctx-update-feed': () => Comm.callMaster(
@@ -1004,15 +994,10 @@ export let FeedListContextMenu = {
             document.getElementById(id).addEventListener('click', handlers[id]);
         }
         document.getElementById('feed-list-context-menu')
-            .addEventListener('show', () => this.init());
+            .addEventListener('show', () => this.prepare());
     },
 
-    get menu() {
-        delete this.menu;
-        return this.menu = document.getElementById('feed-list-context-menu');
-    },
-
-    init() {
+    prepare() {
         let folder = FeedList.selectedItem.nodeName === 'tree-folder';
         this.menu.classList.toggle('folder', folder);
 

--- a/ui/feedlist.js
+++ b/ui/feedlist.js
@@ -308,7 +308,7 @@ export let ViewList = {
         this.tree.selectedItem = aItem;
     },
 
-    init: function ViewList_init(db) {
+    init(db) {
         this.db = db;
         this.tree.root.addEventListener(
             'change', event => this.onSelect(event), {passive: true});
@@ -490,7 +490,7 @@ export let TagList = {
         }
     },
 
-    _rebuild: async function TagList__rebuild() {
+    async _rebuild() {
         let tagList = []; //TODO: restore tag list
 
         if(this.tags !== tagList) {
@@ -703,7 +703,7 @@ export let FeedList = {
         return "/icons/default-feed-favicon.png";
     },
 
-    rebuild: function FeedList_rebuild(feeds) {
+    rebuild(feeds) {
         this._feedsCache = feeds || this.db.feeds;
 
         let active = (this.tree.selectedItem !== null);
@@ -810,7 +810,7 @@ export let ContextMenuModule = {
     _observer: null,
     _currentTarget: null,
 
-    init: function ContextMenu_init() {
+    init() {
         this._observer = new MutationObserver((records) => this._observeMutations(records));
         this._observer.observe(document, {subtree: true,
             childList: true, attributes: true, attributeFilter: ['contextmenu', 'data-dropdown']});
@@ -920,7 +920,7 @@ export let ViewListContextMenu = {
             document.getElementById(id).addEventListener('click', handlers[id]);
         }
         document.getElementById('view-list-context-menu')
-            .addEventListener('show', () => this.init());
+            .addEventListener('show', () => this.prepare());
     },
 
     get menu() {
@@ -930,7 +930,7 @@ export let ViewListContextMenu = {
 
     targetItem: null,
 
-    init: function ViewListContextMenu_init() {
+    prepare() {
         this.targetItem = ViewList.selectedItem;
         this.menu.dataset.target = this.targetItem.id;
     },
@@ -1011,7 +1011,7 @@ export let FeedListContextMenu = {
         return this.menu = document.getElementById('feed-list-context-menu');
     },
 
-    init: function FeedContextMenu_init() {
+    init() {
         let folder = FeedList.selectedItem.nodeName === 'tree-folder';
         this.menu.classList.toggle('folder', folder);
 

--- a/ui/feedlist.js
+++ b/ui/feedlist.js
@@ -224,14 +224,16 @@ TreeView.prototype = {
                 targetNode = targetNode.parentNode;
             }
             event.preventDefault();
-            let ev = new CustomEvent('move');
             let list = dataTransfer.getData('application/x-tree-item-list');
-            ev.itemIds = JSON.parse(list);
-            ev.targetId = targetNode.dataset.id;
-            ev.relation = 'before';
+            let relation = 'before';
             if(event.currentTarget.localName === 'tree-folder-footer') {
-                ev.relation = 'into';
+                relation = 'into';
             }
+            let ev = new CustomEvent('move', {detail: {
+                itemIds: JSON.parse(list),
+                targetId: targetNode.dataset.id,
+                relation,
+            }});
             this.root.dispatchEvent(ev);
             this.root.classList.remove('drag');
             return;
@@ -529,7 +531,7 @@ export let FeedList = {
         this.tree.root.addEventListener(
             'change', () => this.onSelect(), {passive: true});
         this.tree.root.addEventListener(
-            'move', event => this.onMove(event), {passive: true});
+            'move', event => this.onMove(event.detail), {passive: true});
         this.tree.root.addEventListener(
             'keydown', event => this.onKeyDown(event), {capture: true});
         this.tree.root.addEventListener(

--- a/ui/feedlist.js
+++ b/ui/feedlist.js
@@ -311,7 +311,7 @@ export let ViewList = {
     init(db) {
         this.db = db;
         this.tree.root.addEventListener(
-            'change', event => this.onSelect(event), {passive: true});
+            'change', () => this.onSelect(), {passive: true});
 
         this.deselect();
 
@@ -414,7 +414,7 @@ export let TagList = {
     init(db) {
         this.db = db;
         this.tree.root.addEventListener(
-            'change', event => this.onSelect(event), {passive: true});
+            'change', () => this.onSelect(), {passive: true});
 
         TagListContextMenu.build();
     },
@@ -531,7 +531,7 @@ export let FeedList = {
         // TODO: observers should be here
         this._feedsCache = this.db.feeds;
         this.tree.root.addEventListener(
-            'change', event => this.onSelect(event), {passive: true});
+            'change', () => this.onSelect(), {passive: true});
         this.tree.root.addEventListener(
             'move', event => this.onMove(event), {passive: true});
         this.tree.root.addEventListener(
@@ -817,7 +817,7 @@ export let ContextMenuModule = {
 
         this._initSubtrees([document.documentElement]);
 
-        document.addEventListener('blur', event => this._hide(event));
+        document.addEventListener('blur', () => this._hide());
         document.addEventListener('contextmenu', event => this.show(event));
         document.addEventListener('click', event => this.show(event));
     },

--- a/ui/feedlist.js
+++ b/ui/feedlist.js
@@ -1136,9 +1136,9 @@ export let Commands = {
     switchViewFilter: function cmd_switchViewFilter(aFilter) {
         Prefs.set('ui.view.filter', aFilter);
 
-        getElement('show-all-entries-checkbox').dataset.checked = (aFilter === 'all');
-        getElement('filter-unread-checkbox').dataset.checked = (aFilter === 'unread');
-        getElement('filter-starred-checkbox').dataset.checked = (aFilter === 'starred');
+        getElement('show-all-entries-checkbox').dataset.checked = (aFilter === 'all').toString();
+        getElement('filter-unread-checkbox').dataset.checked = (aFilter === 'unread').toString();
+        getElement('filter-starred-checkbox').dataset.checked = (aFilter === 'starred').toString();
 
         if(gCurrentView !== undefined) {
             gCurrentView.setFilter(aFilter);

--- a/ui/feedlist.js
+++ b/ui/feedlist.js
@@ -645,6 +645,7 @@ export let FeedList = {
                 break;
         }
         otherIds.splice(position, 0, ...itemIds);
+        /** @type {{feedID, parent?, rowIndex?}[]} */
         let changes = [{feedID: itemIds[0], parent}];
         for(let [index, feedID] of otherIds.entries()) {
             changes.push({feedID, rowIndex: index + 1});

--- a/ui/feedview.js
+++ b/ui/feedview.js
@@ -797,8 +797,8 @@ FeedView.prototype = {
      */
     enoughEntriesPreloaded: function FeedView__enoughEntriesPreloaded(aWindowHeights) {
         return this._loadedEntries.length > 0 &&
-               (this.window.scrollMaxY - this.window.pageYOffset >
-                this.window.innerHeight * aWindowHeights)
+               (this.document.body.scrollHeight - this.window.pageYOffset  >
+                this.window.innerHeight * (aWindowHeights + 1))
                && this.getEntryInScreenCenter() != this.lastLoadedEntry;
     },
 

--- a/ui/feedview.js
+++ b/ui/feedview.js
@@ -95,8 +95,11 @@ export function FeedView({
 
     this.document.addEventListener('detach-feedview', this);
 
+    // Fixed entry list if not using a query
     if(entries !== null) {
         this._fixedEntries = entries;
+    } else {
+        this._fixedEntries = null;
     }
 
     this.refresh();
@@ -148,9 +151,6 @@ FeedView.prototype = {
 
     // Feed list cache
     _feeds: null,
-
-    // Fixed entry list if not using a query
-    _fixedEntries: null,
 
     // Additional filtering mode (unread / starred / all)
     _filter: 'all',

--- a/ui/feedview.js
+++ b/ui/feedview.js
@@ -738,8 +738,8 @@ FeedView.prototype = {
         // Prevent the message from briefly showing up before entries are loaded.
         this.document.getElementById('message-box').style.display = 'none';
 
-        getElement('full-view-checkbox').dataset.checked = !this.headlinesMode;
-        getElement('headlines-checkbox').dataset.checked = this.headlinesMode;
+        getElement('full-view-checkbox').dataset.checked = (!this.headlinesMode).toString();
+        getElement('headlines-checkbox').dataset.checked = this.headlinesMode.toString();
 
         getElement('view-title-label').textContent = this.titleOverride || this.title;
 

--- a/ui/feedview.js
+++ b/ui/feedview.js
@@ -114,6 +114,7 @@ FeedView.prototype = {
 
     get headlinesMode() {
         let feedIDs = this.query.feeds || this.query.folders;
+        /** @type {boolean | Number} */
         let viewMode = (this._defaultViewMode === 'headlines');
         if (feedIDs && feedIDs.length == 1) {
             viewMode = this.getFeed(feedIDs[0]).viewMode;

--- a/ui/feedview.js
+++ b/ui/feedview.js
@@ -303,7 +303,7 @@ FeedView.prototype = {
 
         this.window.scrollTo({
             top: targetPosition,
-            behavior: aSmooth ? 'smooth' : 'instant',
+            behavior: aSmooth ? 'smooth' : 'auto', // FIXME: is 'auto' correct as 'instant'?
         });
     },
 

--- a/ui/feedview.js
+++ b/ui/feedview.js
@@ -1371,14 +1371,14 @@ EntryView.prototype = {
                     let minuteForm = getPluralForm(
                         relativeDate.deltaMinutes, Strings['minute_pluralForms']);
                     return browser.i18n.getMessage('entryDate_ago', minuteForm)
-                        .replace('#number', relativeDate.deltaMinutes);
+                        .replace('#number', relativeDate.deltaMinutes.toString());
                 }
 
                 case relativeDate.deltaHours <= 12: {
                     let hourForm = getPluralForm(
                         relativeDate.deltaHours, Strings['hour_pluralForms']);
                     return browser.i18n.getMessage('entryDate_ago', hourForm)
-                        .replace('#number', relativeDate.deltaHours);
+                        .replace('#number', relativeDate.deltaHours.toString());
                 }
 
                 case relativeDate.deltaDaySteps === 0:

--- a/ui/feedview.js
+++ b/ui/feedview.js
@@ -28,15 +28,6 @@ const TUTORIAL_URL = "/ui/firstrun.xhtml?tutorial";
 
 /**
  * Manages the display of feed content.
- *
- * @param title
- *        Title of the view which will be shown in the header.
- * @param query
- *        Query that selects entries contained by the view.
- * @param db
- *        The database handle (or `null` for in-memory entry lists)
- * @param feeds
- *        The feed list to be used if not using `db`
  */
 export function FeedView({
     title, filter='all', mode='full', query={}, entries=null, db=null, feeds=null,

--- a/ui/feedview.js
+++ b/ui/feedview.js
@@ -1523,7 +1523,7 @@ async function showElement(aElement, aAnimate) {
     }
 }
 
-/** @type any */
+/** @type {Object.<string, string>} */
 const Strings = new Proxy({}, {
     get(target, prop) {
         if(target[prop] === undefined) {

--- a/ui/feedview.js
+++ b/ui/feedview.js
@@ -1141,8 +1141,6 @@ EntryView.prototype = {
             this.container.classList.remove('starred');
             button.setAttribute('title', Strings.bookmarkEntryTooltip);
         }
-
-        return this.__starred = aValue;
     },
 
 
@@ -1151,7 +1149,6 @@ EntryView.prototype = {
     },
     set tags(aValue) {
         this._getElement('tags').textContent = aValue.sort().join(', ');
-        return this.__tags = aValue;
     },
 
 
@@ -1170,8 +1167,6 @@ EntryView.prototype = {
             this.container.classList.add('selected');
         else
             this.container.classList.remove('selected');
-
-        return aValue;
     },
 
 

--- a/ui/feedview.js
+++ b/ui/feedview.js
@@ -45,6 +45,9 @@ export function FeedView({
     this.db = db;
     this._filter = filter;
     this._defaultViewMode = mode;
+    this._viewID = null;
+    this.__selectedEntry = null;
+    this._markVisibleTimeout = null;
 
     if(db !== null) {
         this._feeds = db.feeds;
@@ -412,7 +415,7 @@ FeedView.prototype = {
 
 
     uninit: function FeedView_uninit() {
-        this.viewID = null;
+        this._viewID = null;
 
         document.removeEventListener('visibilitychange', this, false);
         this.window.removeEventListener('resize', this, false);
@@ -711,7 +714,7 @@ FeedView.prototype = {
      * Refreshes the feed view. Removes the old content and builds the new one.
      */
     refresh: function FeedView_refresh() {
-        this.viewID = Math.floor(Math.random() * 1000000);
+        this._viewID = Math.floor(Math.random() * 1000000);
 
         // Reset view state.
         this._loading = false;
@@ -957,11 +960,11 @@ FeedView.prototype = {
      * stop execution.
      */
     _refreshGuard: function FeedView__refreshGuard(aWrappedPromise) {
-        let oldViewID = this.viewID;
+        let oldViewID = this._viewID;
 
         return aWrappedPromise.then(
             value => {
-                if (this.viewID == oldViewID)
+                if (this._viewID == oldViewID)
                     return value;
                 else
                     throw REFRESH_ABORT;
@@ -977,10 +980,10 @@ FeedView.prototype = {
     },
 
     _callbackRefreshGuard: function FeedView__callbackRefreshGuard(aWrappedFunction) {
-        let oldViewID = this.viewID;
+        let oldViewID = this._viewID;
 
         return () => {
-            if (this.viewID == oldViewID)
+            if (this._viewID == oldViewID)
                 aWrappedFunction.apply(undefined, arguments);
         };
     }

--- a/ui/feedview.js
+++ b/ui/feedview.js
@@ -39,6 +39,8 @@ export function FeedView({
     this._viewID = null;
     this.__selectedEntry = null;
     this._markVisibleTimeout = null;
+    // Autoselect timeout ID for clearTimeout
+    this._scrollSelectionTimeout = null;
 
     if(db !== null) {
         this._feeds = db.feeds;
@@ -142,8 +144,6 @@ FeedView.prototype = {
     // have been loaded, but it is false if there *could* be more.
     _allEntriesLoaded: false,
 
-    // Autoselect timeout ID for clearTimeout
-    _scrollSelectionTimeout: null,
     // Position before the next scroll event to determine its direction
     _prevPosition: 0,
 

--- a/ui/feedview.js
+++ b/ui/feedview.js
@@ -1519,31 +1519,12 @@ async function showElement(aElement, aAnimate) {
     }
 }
 
-
-/* global Strings */
-Object.defineProperty(window, 'Strings', {
-    get: () => {
-        let cachedStringsList = [
-            'entryDate_justNow',
-            'minute_pluralForms',
-            'hour_pluralForms',
-            'entryDate_today',
-            'entryDate_yesterday',
-            'entryWasUpdated',
-            'markEntryAsUnreadTooltip',
-            'markEntryAsReadTooltip',
-            'deleteEntryTooltip',
-            'restoreEntryTooltip',
-            'bookmarkEntryTooltip',
-            'editBookmarkTooltip',
-        ];
-
-        let obj = {};
-        for (let stringName of cachedStringsList)
-            obj[stringName] = browser.i18n.getMessage(stringName);
-
-        delete window.Strings;
-        return window.Strings = obj;
-    },
-    configurable: true
+/** @type any */
+const Strings = new Proxy({}, {
+    get(target, prop) {
+        if(target[prop] === undefined) {
+            target[prop] = browser.i18n.getMessage(prop);
+        }
+        return target[prop];
+    }
 });

--- a/ui/feedview.js
+++ b/ui/feedview.js
@@ -77,7 +77,7 @@ export function FeedView({
     getElement('feed-view-header').removeAttribute('border');
 
     if (!this.query.searchString)
-        getElement('searchbar').value = '';
+        (/** @type HTMLInputElement */(getElement('searchbar'))).value = '';
 
     document.addEventListener('visibilitychange', this, false);
 
@@ -165,7 +165,7 @@ FeedView.prototype = {
     _defaultViewMode: 'full',
 
 
-    get browser() { return getElement('feed-view'); },
+    get browser() { return /** @type HTMLIFrameElement */ (getElement('feed-view')); },
 
     get document() { return this.browser.contentDocument; },
 
@@ -684,7 +684,8 @@ FeedView.prototype = {
                 let dayHeader = this.document.getElementById('day' + entryView.day);
 
                 // They day header may have been already removed by another callback.
-                if (dayHeader && (!dayHeader.nextSibling || dayHeader.nextSibling.tagName == 'H1'))
+                let nextSibling = /** @type HTMLElement? */(dayHeader.nextSibling);
+                if (dayHeader && (! nextSibling || nextSibling.tagName == 'H1'))
                     this.feedContent.removeChild(dayHeader);
 
                 if (++removedCount == indices.length) {

--- a/ui/feedview.js
+++ b/ui/feedview.js
@@ -28,6 +28,7 @@ const TUTORIAL_URL = "/ui/firstrun.xhtml?tutorial";
 
 /**
  * Manages the display of feed content.
+ * @param {{title, filter?, mode, query?, entries?, db?, feeds?}} arg
  */
 export function FeedView({
     title, filter='all', mode='full', query={}, entries=null, db=null, feeds=null,
@@ -1517,6 +1518,7 @@ async function showElement(aElement, aAnimate) {
 
 /** @type {Object.<string, string>} */
 const Strings = new Proxy({}, {
+    /** @param {string} prop */
     get(target, prop) {
         if(target[prop] === undefined) {
             target[prop] = browser.i18n.getMessage(prop);

--- a/ui/feedview.js
+++ b/ui/feedview.js
@@ -1056,7 +1056,7 @@ function EntryView(aFeedView, aEntryData) {
     }
 
     if (this.headline) {
-        this.collapse(false);
+        this.collapse();
 
         if (aEntryData.entryURL)
             this._getElement('headline-link').setAttribute('href', aEntryData.entryURL);
@@ -1333,7 +1333,7 @@ EntryView.prototype = {
                 break;
 
             case 'collapse':
-                this.collapse(true);
+                this.collapse();
                 break;
 
             default:

--- a/ui/options/feed-properties.js
+++ b/ui/options/feed-properties.js
@@ -80,12 +80,14 @@ async function init() {
 
     let allFeeds = Database.feeds.filter(f => !f.hidden && !f.isFolder);
     let index = allFeeds.map(f => f.feedID).indexOf(feedID);
-    document.getElementById('next-feed').disabled = (index == allFeeds.length - 1);
-    document.getElementById('previous-feed').disabled = (index == 0);
-    document.getElementById('next-feed').addEventListener('click', () => {
+    let nextButton = /** @type {HTMLButtonElement} */(document.getElementById('next-feed'));
+    nextButton.disabled = (index == allFeeds.length - 1);
+    nextButton.addEventListener('click', () => {
         document.location.search = `?feedID=${allFeeds[index+1].feedID}`;
     });
-    document.getElementById('previous-feed').addEventListener('click', () => {
+    let prevButton = /** @type {HTMLButtonElement} */(document.getElementById('previous-feed'));
+    prevButton.disabled = (index == 0);
+    prevButton.addEventListener('click', () => {
         document.location.search = `?feedID=${allFeeds[index-1].feedID}`;
     });
     window.addEventListener(
@@ -107,7 +109,7 @@ async function init() {
 }
 
 function updateScale() {
-    let scaleMenu = document.getElementById('update-time-menulist');
+    let scaleMenu = /** @type {HTMLSelectElement} */ (document.getElementById('update-time-menulist'));
     let interval = document.getElementById('updateInterval');
     let scale = 1;
     switch (scaleMenu.selectedIndex) {
@@ -127,7 +129,7 @@ function setFeed(feed) {
 
     // Guess interval scale
     let interval = document.getElementById('updateInterval');
-    let scaleMenu = document.getElementById('update-time-menulist');
+    let scaleMenu = /** @type {HTMLSelectElement} */ (document.getElementById('update-time-menulist'));
     let value = PrefBinder.getValue(interval);
     let asDays = value / (1000*60*60*24);
     let asHours = value / (1000*60*60);

--- a/ui/options/options-common.js
+++ b/ui/options/options-common.js
@@ -19,7 +19,7 @@ export let PrefBinder = {
 
     refresh() {
         for(let node of document.querySelectorAll('[data-pref]')) {
-            let name = node.dataset.pref;
+            let name = (/** @type {HTMLElement} */(node)).dataset.pref;
             let value = this.getter(name);
             this._setValue(node, value);
         }
@@ -93,8 +93,9 @@ export let PrefBinder = {
 
 export let Enabler = {
     init() {
-        for(let node of document.querySelectorAll('[data-requires]')) {
-            let master = document.getElementById(node.dataset.requires);
+        for(let candidate of document.querySelectorAll('[data-requires]')) {
+            let node = /** @type {HTMLInputElement | HTMLSelectElement} */ (candidate);
+            let master = /** @type {HTMLInputElement} */(document.getElementById(node.dataset.requires));
             node.disabled = !master.checked;
             master.addEventListener('change', () => {
                 node.disabled = !master.checked;

--- a/ui/options/options.js
+++ b/ui/options/options.js
@@ -23,7 +23,7 @@ async function init() {
 }
 
 function initUpdateIntervalControls() {
-    let scaleMenu = document.getElementById('update-time-menulist');
+    let scaleMenu = /** @type {HTMLSelectElement} */ (document.getElementById('update-time-menulist'));
     let interval = document.getElementById('updateInterval');
 
     scaleMenu.addEventListener('change', () => {

--- a/ui/shortcuts.js
+++ b/ui/shortcuts.js
@@ -7,8 +7,9 @@ async function onload() {
         ? document.getElementsByClassName('noMac')
         : document.getElementsByClassName('onlyMac');
 
-    for (let i = 0; i < elems.length; i++)
-        elems[i].style.display = 'none';
+    for (let i = 0; i < elems.length; i++) {
+        (/** @type HTMLElement */ (elems[i])).style.display = 'none';
+    }
 
     // Workaround for mozilla bug 1408446
     let {id, height} = await browser.windows.getCurrent();


### PR DESCRIPTION
Use Typescript in its JS mode as an additional linter. Type information can allow it to catch many additional errors (and there is at least one fixed in this PR).