### PR TITLE
Security: Unvalidated remote URL fetch from feed metadata (SSRF/internal network exposure)

### DIFF
--- a/modules/favicon-fetcher.js
+++ b/modules/favicon-fetcher.js
@@ -3,6 +3,70 @@ import {Comm, wait, xhrPromise} from "./utils.js";
 
 const DEFAULT_TIMEOUT = 25000;
 
+const BLOCKED_HOSTNAMES = new Set([
+    "localhost",
+    "127.0.0.1",
+    "0.0.0.0",
+    "::1",
+    "[::1]",
+]);
+
+function isPrivateIPv4(hostname) {
+    let parts = hostname.split(".");
+    if(parts.length !== 4) {
+        return false;
+    }
+    let nums = parts.map(part => Number(part));
+    if(nums.some(num => !Number.isInteger(num) || num < 0 || num > 255)) {
+        return false;
+    }
+    return nums[0] === 10
+        || nums[0] === 127
+        || (nums[0] === 169 && nums[1] === 254)
+        || (nums[0] === 172 && nums[1] >= 16 && nums[1] <= 31)
+        || (nums[0] === 192 && nums[1] === 168);
+}
+
+function isPrivateIPv6(hostname) {
+    let normalized = hostname.toLowerCase();
+    return normalized === "::"
+        || normalized === "::1"
+        || normalized.startsWith("fc")
+        || normalized.startsWith("fd")
+        || normalized.startsWith("fe8")
+        || normalized.startsWith("fe9")
+        || normalized.startsWith("fea")
+        || normalized.startsWith("feb");
+}
+
+function isAllowedRemoteURL(url) {
+    let parsed;
+    try {
+        parsed = url instanceof URL ? url : new URL(url);
+    } catch {
+        return false;
+    }
+
+    if(parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        return false;
+    }
+
+    let hostname = parsed.hostname.toLowerCase();
+    if(!hostname) {
+        return false;
+    }
+
+    if(BLOCKED_HOSTNAMES.has(hostname) || hostname.endsWith(".localhost") || hostname.endsWith(".local")) {
+        return false;
+    }
+
+    if(isPrivateIPv4(hostname) || (hostname.includes(":") && isPrivateIPv6(hostname))) {
+        return false;
+    }
+
+    return true;
+}
+
 /**
  * @typedef {import("/modules/database.js").Database} Database
  */
@@ -50,14 +114,16 @@ export async function fetchFaviconAsURL(feed) {
  * @param {{feedID: string, websiteURL?: string?, title?: string?}} feed
  */
 async function fetchFaviconHardcodedURL(feed) {
-    if (!feed.websiteURL) {
+    if (!feed.websiteURL || !isAllowedRemoteURL(feed.websiteURL)) {
         return;
     }
+
+    let parsedWebsiteURL = new URL(feed.websiteURL);
 
     // Use websiteURL instead of feedURL for resolving the favicon URL,
     // because many websites use services like Feedburner for generating their
     // feeds and we would get the Feedburner's favicon instead.
-    let faviconURL = new URL('/favicon.ico', feed.websiteURL);
+    let faviconURL = new URL('/favicon.ico', parsedWebsiteURL);
 
     let favicon = await fetchFaviconFromURL(feed, faviconURL);
     return favicon;
@@ -67,11 +133,11 @@ async function fetchFaviconHardcodedURL(feed) {
  * @param {{feedID: string, websiteURL?: string, title?: string?}} feed
  */
 async function fetchFaviconWebsiteURL(feed) {
-    if (!feed.websiteURL) {
+    if (!feed.websiteURL || !isAllowedRemoteURL(feed.websiteURL)) {
         return;
     }
 
-    let url = feed.websiteURL;
+    let url = new URL(feed.websiteURL).href;
     let doc = await fetchDocFromURL(url);
 
     let faviconURL = getFaviconURLFromDoc(feed, doc);
@@ -88,10 +154,13 @@ async function fetchFaviconWebsiteURL(feed) {
  * @param {{feedID: string, websiteURL?: string, title?: string?}} feed
  */
 async function fetchFaviconOriginURL(feed) {
-    if (!feed.websiteURL) {
+    if (!feed.websiteURL || !isAllowedRemoteURL(feed.websiteURL)) {
         return;
     }
     let url = new URL(feed.websiteURL).origin;
+    if(!isAllowedRemoteURL(url)) {
+        return;
+    }
     let doc = await fetchDocFromURL(url);
 
     let faviconURL = getFaviconURLFromDoc(feed, doc);
@@ -106,7 +175,7 @@ async function fetchFaviconOriginURL(feed) {
 
 /** @param {string?} url */
 async function fetchDocFromURL(url) {
-    if (!url) {
+    if (!url || !isAllowedRemoteURL(url)) {
         return;
     }
     let websiteRequest = new XMLHttpRequest();
@@ -125,9 +194,13 @@ async function fetchDocFromURL(url) {
  * @param {URL} faviconURL
  */
 async function fetchFaviconFromURL(feed, faviconURL) {
+    if(!isAllowedRemoteURL(faviconURL)) {
+        return;
+    }
+
     let response = await fetch(faviconURL, {redirect: 'follow'});
 
-    if(!response.ok) {
+    if(!response.ok || !isAllowedRemoteURL(response.url)) {
         if(Comm.verbose) {
             console.log(
                 "Brief: failed to resolve favicon for feed ",


### PR DESCRIPTION
## Problem

Favicon fetching uses feed-provided `websiteURL` to request documents and icons (`XMLHttpRequest` + `fetch`) without scheme/host validation. A malicious feed can force requests to internal hosts (e.g., localhost/intranet), turning the extension into a network probe and leaking request side effects.

**Severity**: `medium`
**File**: `modules/favicon-fetcher.js`

## Solution

Validate and restrict URL schemes to `http`/`https`, block localhost/private IP ranges unless explicitly allowed, enforce size/time limits, and consider a denylist for sensitive endpoints (metadata services, loopback).

## Changes

- `modules/favicon-fetcher.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
